### PR TITLE
Timezones; support for `in x units`; breaking changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target
 **/*.rs.bk
 src/main.rs
+/.idea/.gitignore
+/.idea/modules.xml
+/.idea/two-timer.iml
+/.idea/vcs.xml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,13 @@
 name = "two_timer"
 version = "2.2.1"
 authors = ["dfhoughton <dfhoughton@gmail.com>"]
-description="parser for English time expressions"
-homepage="https://github.com/dfhoughton/two-timer"
-repository="https://github.com/dfhoughton/two-timer"
+description = "parser for English time expressions"
+homepage = "https://github.com/dfhoughton/two-timer"
+repository = "https://github.com/dfhoughton/two-timer"
 documentation = "https://docs.rs/two_timer"
-keywords=["time", "nlp", "parse"]
-categories=["date-and-time", "parsing"]
-license="MIT"
+keywords = ["time", "nlp", "parse"]
+categories = ["date-and-time", "parsing"]
+license = "MIT"
 edition = "2018"
 
 [profile.release]
@@ -20,6 +20,7 @@ lazy_static = "1.4"
 chrono = "0.4"
 regex = "1"
 serde_json = "1"
+# chrono-tz = "0.5.3"
 
 [features]
 small_grammar = []

--- a/src/bin/expression_parser.rs
+++ b/src/bin/expression_parser.rs
@@ -2,6 +2,8 @@ extern crate two_timer;
 
 use two_timer::{parse, Config};
 use std::env;
+use chrono_tz::US::Pacific;
+use chrono::Local;
 
 fn main() {
     let mut args = env::args();
@@ -9,7 +11,10 @@ fn main() {
 
     let parse_str = args.collect::<Vec<String>>().join(" ");
 
-    let config = Config::new().default_to_past(false);
+    let config = Config::new(Local::now().with_timezone(&Pacific)).default_to_past(false);
 
-    println!("{:?}", parse(&parse_str, Some(config)));
+    let res = parse(&parse_str, config).unwrap();
+
+    println!("start: {:?}, end: {:?}", res.0, res.1);
+    println!("start_local: {:?}, end_local: {:?}", res.0.with_timezone(&Local), res.1.with_timezone(&Local));
 }

--- a/src/bin/expression_parser.rs
+++ b/src/bin/expression_parser.rs
@@ -2,7 +2,6 @@ extern crate two_timer;
 
 use two_timer::{parse, Config};
 use std::env;
-use chrono_tz::US::Pacific;
 use chrono::Local;
 
 fn main() {
@@ -11,7 +10,9 @@ fn main() {
 
     let parse_str = args.collect::<Vec<String>>().join(" ");
 
-    let config = Config::new(Local::now().with_timezone(&Pacific)).default_to_past(false);
+    let config = Config::new(Local::now())
+        .default_to_past(false)
+        .select_instant(true);
 
     let res = parse(&parse_str, config).unwrap();
 

--- a/src/bin/expression_parser.rs
+++ b/src/bin/expression_parser.rs
@@ -1,0 +1,15 @@
+extern crate two_timer;
+
+use two_timer::{parse, Config};
+use std::env;
+
+fn main() {
+    let mut args = env::args();
+    args.next();
+
+    let parse_str = args.collect::<Vec<String>>().join(" ");
+
+    let config = Config::new().default_to_past(false);
+
+    println!("{:?}", parse(&parse_str, Some(config)));
+}

--- a/src/bin/serializer.rs
+++ b/src/bin/serializer.rs
@@ -1,7 +1,0 @@
-extern crate two_timer;
-extern crate serde_json;
-
-// for constructing a serialized matcher
-pub fn main() {
-    println!("serde_json::from_str(r#\"{}\"#).unwrap();", serde_json::to_string(&two_timer::GRAMMAR.matcher().unwrap()).unwrap());
-}


### PR DESCRIPTION
This is still a draft- I haven't tested this fully yet.

## 1: timezone support
Just a case of going through and replacing `NaiveDateTime` with `DateTime<T>`. In the current iteration, Config must be initialized with a DateTime to fill out the type parameter. I'm trying to figure out if this can be avoided, to retain the old Config interface

...update on this, seems it can't be easily avoided since Chrono doesn't expose a `now` method on `TimeZone`. So this is an unfortunate breaking change

## 2: support 'in x units'
Parser can now handle 'in 10 seconds', 'in 12 days', etc. 
Again, this is still pretty draft. I need to go through and check it hasn't disrupted any other parsing, and that it will recognise other common phrases like 'in a day', or 'in a week'. 

## 3: allow 'on', 'a', 'an' prefixes
Parser can handle 'on Friday', 'in an hour', 'a minute before 8pm', etc.

## 4: add config option to aid with 'in a day'/'a day from now' parser patterns
Potentially there was just a bug here and so this config option should be taken out, however 'a day from now' would return the entire period encapsulating that day, rather than the instant that is one day from now. The config option 'select_instant' fixes this

Other stuff changed:

* A couple of extra gitignore lines just to shut my IDE up.
* Config no longer clones itself when building